### PR TITLE
fix deaths parsing, tablet was renamed on April 1st, 2025

### DIFF
--- a/tibiakt-core/src/main/kotlin/com/galarzaa/tibiakt/core/parsers/CharacterParser.kt
+++ b/tibiakt-core/src/main/kotlin/com/galarzaa/tibiakt/core/parsers/CharacterParser.kt
@@ -59,7 +59,7 @@ public object CharacterParser : Parser<Character?> {
             tables["Account Badges"]?.apply { parseAccountBadges(this) }
             tables["Account Achievements"]?.apply { parseAccountAchievements(this) }
             tables["Account Information"]?.apply { parseAccountInformation(this) }
-            tables["Character Deaths"]?.apply { parseCharacterDeaths(this) }
+            tables["Character Deaths (Last 30 Days)"]?.apply { parseCharacterDeaths(this) }
             tables["Characters"]?.apply { parseCharacters(this) }
         }
 


### PR DESCRIPTION
https://www.tibia.com/news/?subtopic=newsarchive&id=8324

> Character Deaths on the website has been consistently renamed to Character Deaths (Last 30 Days).