### PR TITLE
fix: boosted boss table structure changed

### DIFF
--- a/tibiakt-core/src/main/kotlin/com/galarzaa/tibiakt/core/parsers/BoostableBossesParser.kt
+++ b/tibiakt-core/src/main/kotlin/com/galarzaa/tibiakt/core/parsers/BoostableBossesParser.kt
@@ -36,7 +36,8 @@ public object BoostableBossesParser : Parser<BoostableBosses> {
                     ?: throw ParsingException("boosted boss image not found")
                 val fileName = File(URL(boostedCreatureImageUrl).path).name.remove(".gif")
                 boostedBoss {
-                    name = it.selectFirst("b")?.cleanText() ?: throw ParsingException("Boss title not found")
+                    name = it.selectFirst("p")?.cleanText()?.substringAfter("Today's boosted boss: ")
+                        ?: throw ParsingException("Boss title not found")
                     identifier = fileName
                 }
             } ?: throw ParsingException("Boosted boss table not found.")

--- a/tibiakt-core/src/test/kotlin/com/galarzaa/tibiakt/core/parsers/BoostableBossesTests.kt
+++ b/tibiakt-core/src/test/kotlin/com/galarzaa/tibiakt/core/parsers/BoostableBossesTests.kt
@@ -25,8 +25,8 @@ class BoostableBossesTests : FunSpec({
     test("Boostable Bosses List") {
         val boostableBosses = BoostableBossesParser.fromContent(getResource("boostableBosses/bossList.txt"))
         with(boostableBosses.boostedBoss) {
-            name shouldBe "Tentugly"
-            identifier shouldBe "fakeseamonster"
+            name shouldBe "Abyssador"
+            identifier shouldBe "abyssador"
         }
         boostableBosses.bosses shouldHaveAtLeastSize 1
     }

--- a/tibiakt-core/src/test/resources/boostableBosses/bossList.txt
+++ b/tibiakt-core/src/test/resources/boostableBosses/bossList.txt
@@ -1,51 +1,50 @@
+<html lang="en"><head>
+  <title>Tibia - Free Multiplayer Online Role Playing Game - Library</title>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">  <meta name="description" content="Tibia is a free massively multiplayer online role-playing game (MMORPG). Join this fascinating game that has thousands of fans from all over the world! - https://www.tibia.com">
+  <meta name="author" content="CipSoft GmbH">
+  <meta http-equiv="content-language" content="en">
+  <meta name="keywords" content="free online game, free multiplayer game, free online rpg, free mmorpg, mmorpg, mmog, online role playing game, online multiplayer game, internet game, online rpg, rpg">
+  <meta name="google-site-verification" content="DnO3wR8m-XUPrU02NoZt9x3vMB0fjpOXXJshbKucEj8">
+  <!-- set viewport to improve display on mobile devices -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, viewport-fit=cover">
+  <!-- Open Graph Meta Tags -->
+  <meta property="og:title" content="Tibia - Free Multiplayer Online Role Playing Game">
+<meta property="og:url" content="https://tibia.com">
+<meta property="og:type" content="website">
+<meta property="og:description" content="Tibia is a free massively multiplayer online role-playing game (MMORPG). Join this fascinating game that has thousands of fans from all over the world!">
+<meta property="og:image" content="https://static.tibia.com/images/global/og-meta/official-tibia-site_wide.png">
+<meta property="og:image:alt" content="Official Tibia Website">
+<meta property="og:image:width" content="600">
+<meta property="og:image:height" content="315">
 
+  <!--  regular browsers -->
+  <link rel="shortcut icon" href="https://static.tibia.com/images/global/general/favicon.ico" type="image/x-icon">
+  <!-- For iPad with high-resolution Retina display running iOS = 7: -->
+  <link rel="apple-touch-icon" sizes="152x152" href="https://static.tibia.com/images/global/general/apple-touch-icon-152x152.png">
+  <!-- For iPad with high-resolution Retina display running iOS = 6: -->
+  <link rel="apple-touch-icon" sizes="144x144" href="https://static.tibia.com/images/global/general/apple-touch-icon-144x144.png">
+  <!-- For iPhone with high-resolution Retina display running iOS = 7: -->
+  <link rel="apple-touch-icon" sizes="120x120" href="https://static.tibia.com/images/global/general/apple-touch-icon-120x120.png">
+  <!-- For iPhone with high-resolution Retina display running iOS = 6: -->
+  <link rel="apple-touch-icon" sizes="114x114" href="https://static.tibia.com/images/global/general/apple-touch-icon-114x114.png">
+  <!-- For the iPad mini and the first- and second-generation iPad on iOS = 7: -->
+  <link rel="apple-touch-icon" sizes="76x76" href="https://static.tibia.com/images/global/general/apple-touch-icon-76x76.png">
+  <!-- For the iPad mini and the first- and second-generation iPad on iOS = 6: -->
+  <link rel="apple-touch-icon" sizes="72x72" href="https://static.tibia.com/images/global/general/apple-touch-icon-72x72.png">
+  <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
+  <link rel="apple-touch-icon" href="https://static.tibia.com/images/global/general/apple-touch-icon.png">
+  <!-- Fallback for older devices: -->
+  <link rel="apple-touch-icon-precomposed" href="https://static.tibia.com/images/global/general/apple-touch-icon-precomposed.png">
+  <!-- styles -->
+  <link href="https://static.tibia.com/styles/basic_part_1.css?version=6986040b7b272176daa257f66d56e8ef" rel="stylesheet" type="text/css">
+    <link href="https://static.tibia.com/styles/basic_part_3.css?version=5f5fb3d216e4d933c2ac92b3f82928b9" rel="stylesheet" type="text/css">
+  <link href="https://static.tibia.com/styles/global_part_1.css?version=134928da08d74986964593538f46d0e0" rel="stylesheet" type="text/css">
+    <link href="https://static.tibia.com/styles/global_part_2.css?version=c868a2730435034573b0cdf1625e9226" rel="stylesheet" type="text/css">
+      <link rel="stylesheet" href="https://static.tibia.com/javascripts/intl-tel-input/build/css/intlTelInput.css">
 
-<!DOCTYPE html>
-<html>
-<head>
-<title>Tibia - Free Multiplayer Online Role Playing Game - Library</title>
-<meta http-equiv="content-type" content="text/html; charset=ISO-8859-1" /> <meta name="description" content="Tibia is a free massively multiplayer online role-playing game (MMORPG). Join this fascinating game that has thousands of fans from all over the world! - http://www.tibia.com" />
-<meta name="author" content="CipSoft GmbH" />
-<meta http-equiv="content-language" content="en" />
-<meta name="keywords" content="free online game, free multiplayer game, free online rpg, free mmorpg, mmorpg, mmog, online role playing game, online multiplayer game, internet game, online rpg, rpg" />
-<meta name="google-site-verification" content="DnO3wR8m-XUPrU02NoZt9x3vMB0fjpOXXJshbKucEj8" />
-
-<meta property="og:title" content="Tibia - Free Multiplayer Online Role Playing Game" />
-<meta property="og:url" content="http://tibia.com" />
-<meta property="og:type" content="website" />
-<meta property="og:description" content="Tibia is a free massively multiplayer online role-playing game (MMORPG). Join this fascinating game that has thousands of fans from all over the world!" />
-<meta property="og:image" content="https://static.tibia.com/images/global/og-meta/official-tibia-site_wide.png" />
-<meta property="og:image:alt" content="Official Tibia Website" />
-<meta property="og:image:width" content="600" />
-<meta property="og:image:height" content="315" />
-<meta property="fb:app_id" content="497232093667125" />
-
-<link rel="shortcut icon" href="https://static.tibia.com/images/global/general/favicon.ico" type="image/x-icon">
-
-<link rel="apple-touch-icon" sizes="152x152" href="https://static.tibia.com/images/global/general/apple-touch-icon-152x152.png">
-
-<link rel="apple-touch-icon" sizes="144x144" href="https://static.tibia.com/images/global/general/apple-touch-icon-144x144.png">
-
-<link rel="apple-touch-icon" sizes="120x120" href="https://static.tibia.com/images/global/general/apple-touch-icon-120x120.png">
-
-<link rel="apple-touch-icon" sizes="114x114" href="https://static.tibia.com/images/global/general/apple-touch-icon-114x114.png">
-
-<link rel="apple-touch-icon" sizes="76x76" href="https://static.tibia.com/images/global/general/apple-touch-icon-76x76.png">
-
-<link rel="apple-touch-icon" sizes="72x72" href="https://static.tibia.com/images/global/general/apple-touch-icon-72x72.png">
-
-<link rel="apple-touch-icon" href="https://static.tibia.com/images/global/general/apple-touch-icon.png">
-
-<link rel="apple-touch-icon-precomposed" href="https://static.tibia.com/images/global/general/apple-touch-icon-precomposed.png">
-
-<link href="https://static.tibia.com/styles/basic_part_1.css?version=31bda467a9174846c15f8f92c191e163" rel="stylesheet" type="text/css">
-<link href="https://static.tibia.com/styles/basic_part_2.css?version=cc53cee36733c2063b684c7c3fdce3df" rel="stylesheet" type="text/css">
-<link href="https://static.tibia.com/styles/basic_part_3.css?version=da83ab6a5c4bd25ccf28a8c1081db8fe" rel="stylesheet" type="text/css">
-<link href="https://static.tibia.com/styles/global.css?version=4946c76510778bc08fd4b8180d8eff1d" rel="stylesheet" type="text/css">
-<link rel="stylesheet" href="https://static.tibia.com/javascripts/intl-tel-input/build/css/intlTelInput.css">
-<script type="application/ld+json">
+    <script type="application/ld+json">
     {
-      "@context": "http://schema.org",
+      "@context": "https://schema.org",
       "@type":"VideoGame",
       "name":[
         {
@@ -63,9 +62,9 @@
         "MMORPG",
         "Massively multiplayer online role-playing game"
       ],
-      "url":"https://secure.tibia.com",
+      "url":"https://www.tibia.com",
       "image":"https://static.tibia.com/images/global/general/streaming/youtube/poster.jpg",
-      "screenshot":"https://static.tibia.com/images/images/global/general/streaming/youtube/backgroundart.jpg",
+      "screenshot":"https://static.tibia.com/images/global/general/streaming/youtube/backgroundart.jpg",
       "sameAs": [
         "https://en.wikipedia.org/wiki/Tibia_(video_game)",
         "https://www.youtube.com/channel/UCkOpOASkwLvVDyGUQ6T8IAA"
@@ -79,729 +78,693 @@
         "thumbnailUrl":"https://static.tibia.com/images/global/general/video-frame-big.png",
         "uploadDate":"2016-01-13"
       },
-        "applicationCategory":"Game",
-        "operatingSystem":"Windows 7 or newer, Linux, macOS"
+      "applicationCategory":"Game",
+      "operatingSystem":"Windows 10 or newer, Linux, macOS"
     }
-  </script> <script type="text/javascript" src="https://static.tibia.com/javascripts/jquery-3.6.0.min.js"></script>
-<script type="text/javascript" src="https://static.tibia.com/javascripts/ajaxcip_tibia_v1.js"></script>
-<script type="text/javascript">
-  var loginStatus=0; loginStatus='false';  var activeSubmenuItem='boostablebosses';  var JS_DIR_IMAGES=0; JS_DIR_IMAGES='https://static.tibia.com/images/';  var JS_DIR_ACCOUNT=0; JS_DIR_ACCOUNT='https://www.tibia.com/account/';  var JS_DIR_COMMUNITY=0; JS_DIR_COMMUNITY='https://www.tibia.com/community/';  var JS_DIR_WEBSITESERVICES=0; JS_DIR_WEBSITESERVICES='https://www.tibia.com/websiteservices/';  var JS_FACEBOOKAPPID = '497232093667125';  var JS_COOKIE_DOMAIN=0; JS_COOKIE_DOMAIN='.tibia.com';  var g_FormName='';  var g_FormField='';  var g_Deactivated=false;  var JS_ANNIVERSARY_THEMEBOX_STEP_1=0; JS_ANNIVERSARY_THEMEBOX_STEP_1='1639386000';  var JS_ANNIVERSARY_THEMEBOX_STEP_2=0; JS_ANNIVERSARY_THEMEBOX_STEP_2='1641373200';  var JS_ANNIVERSARY_THEMEBOX_STEP_3=0; JS_ANNIVERSARY_THEMEBOX_STEP_3='1641546000';var FB_TryLogin = 0;var FB_ForceReload = 0;</script>
-<script type="text/javascript">
-</script>
-<script type="text/javascript" src="https://static.tibia.com/javascripts/zxcvbn.js?version=2f0541a1e9b57dfb523f34754a8ba59f"></script>
-<script type="text/javascript" src="https://static.tibia.com/javascripts/global.js?version=cf72fc27df1e33e17af723746a5bda2c"></script>
-<script type="text/javascript" src="https://static.tibia.com/javascripts/generic.js?version=ddacf3571117020b02261a07633d3694"></script>
-<script type="text/javascript" src="https://static.tibia.com/javascripts/initialize.js?version=57cc36606e00c2966a8b726f80cbd722"></script>
-<script type="text/javascript" src="https://static.tibia.com/javascripts/fb-init.js"></script>
+  </script>  <script type="text/javascript" src="https://static.tibia.com/javascripts/jquery.min.js?version=e0f0d67d865fffea6055452ceec50736"></script>
+  <script type="text/javascript" src="https://static.tibia.com/javascripts/ajaxcip_tibia_v1.js"></script>
+        <script type="text/javascript">
+var loginStatus='false'; var activeSubmenuItem='boostablebosses'; const JS_DIR_IMAGES='https://static.tibia.com/images/'; const JS_DIR_ACCOUNT='https://www.tibia.com/account/'; const JS_DIR_COMMUNITY='https://www.tibia.com/community/'; const JS_DIR_SUPPORT='https://www.tibia.com/support/'; const JS_DIR_WEBSITESERVICES='https://www.tibia.com/websiteservices/'; const JS_COOKIE_DOMAIN='.tibia.com'; var g_FormName=''; var g_FormField=''; var g_Deactivated=false;</script>
+  <script type="text/javascript" src="https://static.tibia.com/javascripts/global.js?version=4857b29bd9b7fe2aeff15bfa30063fee"></script>
+  <script type="text/javascript">
+    var LoadMobileCSS = false;
+  </script>
+
+  <script type="text/javascript" src="https://static.tibia.com/javascripts/generic.js?version=56edc5b8ae199497c5da2e52ef10f589"></script>
+  <script type="text/javascript" src="https://static.tibia.com/javascripts/initialize.js?version=bc02856e40267c440418cb2aac10fb0a"></script>
+
 </head>
-<body onBeforeUnLoad="SaveMenu();" onUnload="SaveMenu();" onLoad="SetFormFocus()" style="background-image:url(https://static.tibia.com/images/global/header/background-artwork.jpg);">
-<div id="fb-root"></div>
-<div id="DeactivationContainer" onClick="ActivateWebsiteFrame();$('.LightBoxContentToHide').css('display', 'none');"></div>
-<a name="top"></a>
-<div id="tmp-browser-info">
-<div id="tmp-browser-info-chromium">NO - internet explorer</div>
-<div id="tmp-browser-info-internet-explorer-new">NEW - internet explorer</div>
-<div id="tmp-browser-info-internet-explorer-old">OLD - internet explorer</div>
-</div>
-<div class="main-site-container">
-<div class="main-header"></div>
-<div class="main-menu">
-<div id="MenuColumn">
-<div id="LeftArtwork">
- <a href="https://www.tibia.com/mmorpg/free-multiplayer-online-role-playing-game.php"><img id="TibiaLogoArtworkTop" src="https://static.tibia.com/images/global/header/tibia-logo-artwork-top.gif" alt="logoartwork" /></a>
-<img id="LogoLink" src="https://static.tibia.com/images/global/header/tibia-logo-artwork-string.gif" onClick="window.location = 'https://www.tibia.com/abouttibia/?subtopic=aboutcipsoft';" alt="logoartwork" />
-</div>
-<div class="SmallMenuBorder BorderTop" style="background-image:url(https://static.tibia.com/images/global/general/box-top-large.png);"></div>
-<div class="SmallMenuBox">
-<div class="SmallBoxTop" style="background-image:url(https://static.tibia.com/images/global/general/box-top.gif)"></div>
-<div class="SmallBoxBorder" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif)"></div>
-<div class="SmallBoxButtonContainer" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-textfield-background.gif)">
-<div id="PlayNowContainer"><form class="MediumButtonForm" action="https://www.tibia.com/account/?subtopic=accountmanagement" method="post"><input type="hidden" name="page" value="overview" /><div class="MediumButtonBackground" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton.gif)" onMouseOver="MouseOverMediumButton(this);" onMouseOut="MouseOutMediumButton(this);"><div class="MediumButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton-over.gif)" onMouseOver="MouseOverMediumButton(this);" onMouseOut="MouseOutMediumButton(this);"></div><input class="MediumButtonText" type="image" name="Login" alt="Login" src="https://static.tibia.com/images/global/buttons/mediumbutton_login.png" /></div></form></div>
-</div>
-<div class="Loginstatus" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-textfield-background.gif)">
-<div id="LoginstatusText" onClick="LoginstatusTextAction(this);" onMouseOver="MouseOverLoginBoxText(this);" onMouseOut="MouseOutLoginBoxText(this);"><div id="LoginstatusText_1" class="LoginstatusText" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-font-create-account.gif)"></div><div id="LoginstatusText_2" class="LoginstatusText" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-font-create-account-over.gif)"></div></div>
-</div>
-<div class="SmallBoxBorder BorderRight" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif)"></div>
-<div class="Loginstatus SmallBoxBottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif)"></div>
-</div>
-<div class="SmallMenuBox" id="DownloadBox">
-<div class="SmallBoxTop" style="background-image:url(https://static.tibia.com/images/global/general/box-top.gif)"></div>
-<div class="SmallBoxBorder" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
-<div class="SmallBoxButtonContainer" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-textfield-background.gif)">
-<div id="PlayNowContainer"><form class="MediumButtonForm" action="https://www.tibia.com/account/?subtopic=downloadclient&step=downloadagreement" method="post"><div class="MediumButtonBackground" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton.gif)" onMouseOver="MouseOverMediumButton(this);" onMouseOut="MouseOutMediumButton(this);"><div class="MediumButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton-over.gif)" onMouseOver="MouseOverMediumButton(this);" onMouseOut="MouseOutMediumButton(this);"></div><input class="MediumButtonText" type="image" name="Download" alt="Download" src="https://static.tibia.com/images/global/buttons/mediumbutton_download.png" /></div></form></div>
-</div>
-<div class="SmallBoxBorder BorderRight" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
-<div class="Loginstatus SmallBoxBottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif);"></div>
-</div>
-<div class="SmallMenuBorder BorderBottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom-large.png);"></div><div id='Menu'>
-<div id='MenuTop' style='background-image:url(https://static.tibia.com/images/global/general/box-top.gif);'></div>
-<div id='news' class='menuitem'>
-<span onClick="MenuItemAction('news')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='news_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
+
+<body onbeforeunload="SaveMenu();" onunload="SaveMenu();" onload="SetFormFocus()" style="background-image:url(https://static.tibia.com/images/global/header/background-artwork.webp);">
+
+  <div id="DeactivationContainer" onclick="ActivateWebsiteFrame();$('.LightBoxContentToHide').css('display', 'none');"></div>
+
+  <a name="top"></a>
+
+  <div id="tmp-browser-info">
+    <div id="tmp-browser-info-chromium">NO - internet explorer</div>
+    <div id="tmp-browser-info-internet-explorer-new">NEW - internet explorer</div>
+    <div id="tmp-browser-info-internet-explorer-old">OLD - internet explorer</div>
+  </div>
+
+  <div class="main-site-container">
+    <div class="main-header">
+      <header id="MobileMenu"><nav><div id="MobileMenuBottom"></div><div class="MobileTibiaLogo"><a href="https://www.tibia.com/news/?subtopic=latestnews" aria-label="Go to Tibia news"> </a></div><input type="checkbox" id="MobileShortMenuIcon"><label for="MobileShortMenuIcon" id="MyAccount" class="MobileShortMenuIconContainer MobileNavigationMainElement"></label><ul class="MobileMenuItems MobileShortMenuItems"><li class="Level2Entry MobileNavigationLinkContainer" id="MobileShortMenuMyAccount"><form action="https://www.tibia.com/account/?subtopic=accountmanagement" method="post" style="padding:0px;margin:0px;"><div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_green.gif)"><div onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_green_over.gif);"></div><input class="BigButtonText" type="submit" value="Login"></div></div></form></li><li class="Level2Entry MobileNavigationLinkContainer" id="MobileShortMenuLogout"><form action="https://www.tibia.com/support/?subtopic=gethelp" method="post" style="padding:0px;margin:0px;"><div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue.gif)"><div onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue_over.gif);"></div><input class="BigButtonText" type="submit" value="Support"></div></div></form></li></ul><input type="checkbox" id="MobileMenuIcon"><label for="MobileMenuIcon" class="MobileMenuIconContainer MobileNavigationMainElement"></label><ul class="MobileMenuItems"><li class="Level1Block" id="news"><div class="Level1Entry" onclick="MenuItemAction('news')" ;="">News</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="latestnews"><a class="Level2Entry" href="https://www.tibia.com/news/?subtopic=latestnews">Latest News</a></li><li class="Level2Block MobileNavigationLinkContainer" id="newsarchive"><a class="Level2Entry" href="https://www.tibia.com/news/?subtopic=newsarchive">News Archive</a></li><li class="Level2Block MobileNavigationLinkContainer" id="eventcalendar"><a class="Level2Entry" href="https://www.tibia.com/news/?subtopic=eventcalendar">Event Schedule</a></li></ul></li><li class="Level1Block" id="abouttibia"><div class="Level1Entry" onclick="MenuItemAction('abouttibia')" ;="">About Tibia</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="whatistibia" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/abouttibia/?subtopic=whatistibia">What Is Tibia?</a></li><li class="Level2Block MobileNavigationLinkContainer" id="screenshots" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/abouttibia/?subtopic=screenshots">Screenshots</a></li><li class="Level2Block MobileNavigationLinkContainer" id="gamefeatures" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/abouttibia/?subtopic=gamefeatures">Game Features</a></li><li class="Level2Block MobileNavigationLinkContainer" id="premiumfeatures" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/abouttibia/?subtopic=premiumfeatures">Premium Features</a></li><li class="Level2Block MobileNavigationLinkContainer" id="aboutcipsoft" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/abouttibia/?subtopic=aboutcipsoft">About CipSoft</a></li></ul></li><li class="Level1Block" id="gameguides"><div class="Level1Entry" onclick="MenuItemAction('gameguides')" ;="">Game Guides</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="quickstart" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/gameguides/?subtopic=quickstart">Quickstart</a></li><li class="Level2Block MobileNavigationLinkContainer" id="manual" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/gameguides/?subtopic=manual">Manual</a></li><li class="Level2Block MobileNavigationLinkContainer" id="securityhints" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/gameguides/?subtopic=securityhints">Security Hints</a></li></ul></li><li class="Level1Block" id="library"><div class="Level1Entry" onclick="MenuItemAction('library')" ;="">Library</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="creatures" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=creatures">Creatures</a></li><li class="Level2Block MobileNavigationLinkContainer MobileMenuActiveItem" id="boostablebosses" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=boostablebosses">Boostable Bosses</a></li><li class="Level2Block MobileNavigationLinkContainer" id="spells" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=spells">Spells</a></li><li class="Level2Block MobileNavigationLinkContainer" id="achievements" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=achievements">Achievements</a></li><li class="Level2Block MobileNavigationLinkContainer" id="worldquests" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=worldquests">World Quests</a></li><li class="Level2Block MobileNavigationLinkContainer" id="experiencetable" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=experiencetable">Experience Table</a></li><li class="Level2Block MobileNavigationLinkContainer" id="maps" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=maps">Maps</a></li><li class="Level2Block MobileNavigationLinkContainer" id="genesis" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=genesis">Genesis</a></li><li class="Level2Block MobileNavigationLinkContainer" id="soundtrack" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/library/?subtopic=soundtrack">Soundtrack</a></li></ul></li><li class="Level1Block" id="community"><div class="Level1Entry" onclick="MenuItemAction('community')" ;="">Community</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="characters" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=characters">Characters</a></li><li class="Level2Block MobileNavigationLinkContainer" id="worlds" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=worlds">Worlds</a></li><li class="Level2Block MobileNavigationLinkContainer" id="highscores" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=highscores">Highscores</a></li><li class="Level2Block MobileNavigationLinkContainer" id="leaderboards" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=leaderboards">Leaderboards</a></li><li class="Level2Block MobileNavigationLinkContainer" id="wheelofdestinyplanner" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=wheelofdestinyplanner">Wheel of Destiny Planner</a></li><li class="Level2Block MobileNavigationLinkContainer" id="killstatistics" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=killstatistics">Kill Statistics</a></li><li class="Level2Block MobileNavigationLinkContainer" id="houses" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=houses">Houses</a></li><li class="Level2Block MobileNavigationLinkContainer" id="guilds" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=guilds">Guilds</a></li><li class="Level2Block MobileNavigationLinkContainer" id="polls" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=polls">Polls</a></li><li class="Level2Block MobileNavigationLinkContainer" id="feedbackform" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=feedbackform">Feedback Form</a></li><li class="Level2Block MobileNavigationLinkContainer" id="fansites" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=fansites">Fansites</a></li><li class="Level2Block MobileNavigationLinkContainer" id="resellers" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/community/?subtopic=resellers">Resellers</a></li></ul></li><li class="Level1Block" id="forum"><div class="Level1Entry" onclick="MenuItemAction('forum')" ;="">Forum</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="worldboards" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/forum/?subtopic=worldboards">World Boards</a></li><li class="Level2Block MobileNavigationLinkContainer" id="tradeboards" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/forum/?subtopic=tradeboards">Trade Boards</a></li><li class="Level2Block MobileNavigationLinkContainer" id="communityboards" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/forum/?subtopic=communityboards">Community Boards</a></li><li class="Level2Block MobileNavigationLinkContainer" id="supportboards" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/forum/?subtopic=supportboards">Support Boards</a></li><li class="Level2Block MobileNavigationLinkContainer" id="guildboards" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/forum/?subtopic=guildboards">Guild Boards</a></li><li class="Level2Block MobileNavigationLinkContainer" id="forum" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/forum/?subtopic=forum&amp;action=cm_post_archive">CM Post Archive</a></li></ul></li><li class="Level1Block" id="account"><div class="Level1Entry" onclick="MenuItemAction('account')" ;="">Account</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="accountmanagement" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/account/?subtopic=accountmanagement&amp;page=overview">Account Management</a></li><li class="Level2Block MobileNavigationLinkContainer" id="createaccount" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/account/?subtopic=createaccount">Create Account</a></li><li class="Level2Block MobileNavigationLinkContainer" id="downloadclient" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/account/?subtopic=downloadclient&amp;step=downloadagreement">Download Client</a></li><li class="Level2Block MobileNavigationLinkContainer" id="webshop" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/account/index.php?subtopic=redirectlogin&amp;redirect=https%3A%2F%2Fwww.tibia.com%2Faccount%2F%3Fsubtopic%3Daccountmanagement%23Products%2BAvailable">Webshop</a></li><li class="Level2Block MobileNavigationLinkContainer" id="lostaccount" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/account/?subtopic=lostaccount">Lost Account</a></li></ul></li><li class="Level1Block" id="charactertrade"><div class="Level1Entry" onclick="MenuItemAction('charactertrade')" ;="">Char Bazaar</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="currentcharactertrades" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/charactertrade/?subtopic=currentcharactertrades">Current Auctions</a></li><li class="Level2Block MobileNavigationLinkContainer" id="pastcharactertrades" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/charactertrade/?subtopic=pastcharactertrades">Auction History</a></li><li class="Level2Block MobileNavigationLinkContainer" id="ownbids" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/charactertrade/?subtopic=ownbids">My Bids</a></li><li class="Level2Block MobileNavigationLinkContainer" id="owncharactertrades" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/charactertrade/?subtopic=owncharactertrades">My Auctions</a></li><li class="Level2Block MobileNavigationLinkContainer" id="watchedcharactertrades" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/charactertrade/?subtopic=watchedcharactertrades">My Watched Auctions</a></li></ul></li><li class="Level1Block" id="support"><div class="Level1Entry" onclick="MenuItemAction('support')" ;="">Support</div><ul class=""><li class="Level2Block MobileNavigationLinkContainer" id="gethelp" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/support/?subtopic=gethelp">FAQ</a></li><li class="Level2Block MobileNavigationLinkContainer" id="tibiarules" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/support/?subtopic=tibiarules">Tibia Rules</a></li><li class="Level2Block MobileNavigationLinkContainer" id="parentsguide" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/support/?subtopic=parentsguide">Parents' Guide</a></li><li class="Level2Block MobileNavigationLinkContainer" id="legaldocuments" style="display: none;"><a class="Level2Entry" href="https://www.tibia.com/support/?subtopic=legaldocuments">Legal Documents</a></li></ul></li></ul></nav></header>    </div>
+    <div class="main-menu">
+      <div id="MenuColumn">
+        <div id="LeftArtwork">
+          <a href="https://www.tibia.com/mmorpg/free-multiplayer-online-role-playing-game.php"><img id="TibiaLogoArtworkTop" src="https://static.tibia.com/images/global/header/tibia-logo-artwork-top.gif" alt="logoartwork"></a>
+          <img id="LogoLink" src="https://static.tibia.com/images/global/header/tibia-logo-artwork-string.gif" onclick="window.location = 'https://www.tibia.com/abouttibia/?subtopic=aboutcipsoft';" alt="logoartwork">
+        </div>
+          <div class="SmallMenuBorder BorderTop" style="background-image:url(https://static.tibia.com/images/global/general/box-top-large.png);"></div>
+
+  <div class="SmallMenuBox">
+    <div class="SmallBoxTop" style="background-image:url(https://static.tibia.com/images/global/general/box-top.gif)"></div>
+    <div class="SmallBoxBorder" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif)"></div>
+    <div class="SmallBoxButtonContainer" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-textfield-background.gif)">
+      <div id="PlayNowContainer"><form class="MediumButtonForm" action="https://www.tibia.com/account/?subtopic=accountmanagement" method="post"><input type="hidden" name="page" value="overview"><div class="MediumButtonBackground" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton.gif)" onmouseover="MouseOverMediumButton(this);" onmouseout="MouseOutMediumButton(this);"><div class="MediumButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton-over.gif)" onmouseover="MouseOverMediumButton(this);" onmouseout="MouseOutMediumButton(this);"></div><input class="MediumButtonText" type="image" name="Login" alt="Login" src="https://static.tibia.com/images/global/buttons/mediumbutton_login.png"></div></form></div>
+    </div>
+    <div class="Loginstatus" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-textfield-background.gif)">
+      <div id="LoginstatusText" onclick="LoginstatusTextAction(this);" onmouseover="MouseOverLoginBoxText(this);" onmouseout="MouseOutLoginBoxText(this);"><div id="LoginstatusText_1" class="LoginstatusText" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-font-create-account.gif)"></div><div id="LoginstatusText_2" class="LoginstatusText" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-font-create-account-over.gif)"></div></div>
+    </div>
+    <div class="SmallBoxBorder BorderRight" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif)"></div>
+    <div class="Loginstatus SmallBoxBottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif)"></div>
+  </div>
+
+  <div class="SmallMenuBox" id="DownloadBox">
+    <div class="SmallBoxTop" style="background-image:url(https://static.tibia.com/images/global/general/box-top.gif)"></div>
+    <div class="SmallBoxBorder" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div class="SmallBoxButtonContainer" style="background-image:url(https://static.tibia.com/images/global/loginbox/loginbox-textfield-background.gif)">
+      <div id="PlayNowContainer"><form class="MediumButtonForm" action="https://www.tibia.com/account/?subtopic=downloadclient&amp;step=downloadagreement" method="post"><div class="MediumButtonBackground" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton.gif)" onmouseover="MouseOverMediumButton(this);" onmouseout="MouseOutMediumButton(this);"><div class="MediumButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/mediumbutton-over.gif)" onmouseover="MouseOverMediumButton(this);" onmouseout="MouseOutMediumButton(this);"></div><input class="MediumButtonText" type="image" name="Download" alt="Download" src="https://static.tibia.com/images/global/buttons/mediumbutton_download.png"></div></form></div>
+    </div>
+    <div class="SmallBoxBorder BorderRight" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div class="Loginstatus SmallBoxBottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif);"></div>
+  </div>
+
+  <div class="SmallMenuBorder BorderBottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom-large.png);"></div><div id="Menu">
+<div id="MenuTop" style="background-image:url(https://static.tibia.com/images/global/general/box-top.gif);"></div>
+<div id="news" class="menuitem">
+<span onclick="MenuItemAction('news')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="news_Lights" class="Lights" style="visibility: hidden;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="news_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-news.gif);"></div>
+      <div id="news_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-news.png);"></div>
+      <div id="news_Extend" class="Extend" style="background-image: url(&quot;https://static.tibia.com/images/global/general/minus.gif&quot;);"></div>
+    </div>
+  </div>
 </span>
-<div id='news_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-news.gif);'></div>
-<div id='news_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-news.png);'></div>
-<div id='news_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
+<div id="news_Submenu" class="Submenu" style="visibility: visible; display: block;">
+<a href="https://www.tibia.com/news/?subtopic=latestnews">
+  <div id="submenu_latestnews" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_latestnews" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_latestnews" class="SubmenuitemLabel">Latest News</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/news/?subtopic=newsarchive">
+  <div id="submenu_newsarchive" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_newsarchive" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_newsarchive" class="SubmenuitemLabel">News Archive</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/news/?subtopic=eventcalendar">
+  <div id="submenu_eventcalendar" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_eventcalendar" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_eventcalendar" class="SubmenuitemLabel">Event Schedule</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
 </div>
 </div>
+<div id="abouttibia" class="menuitem">
+<span onclick="MenuItemAction('abouttibia')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="abouttibia_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="abouttibia_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-abouttibia.gif);"></div>
+      <div id="abouttibia_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-abouttibia.png);"></div>
+      <div id="abouttibia_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='news_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/news/?subtopic=latestnews'>
-<div id='submenu_latestnews' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_latestnews' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_latestnews' class='SubmenuitemLabel'>Latest News</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<div id="abouttibia_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/abouttibia/?subtopic=whatistibia">
+  <div id="submenu_whatistibia" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_whatistibia" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_whatistibia" class="SubmenuitemLabel">What Is Tibia?</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/news/?subtopic=newsarchive'>
-<div id='submenu_newsarchive' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_newsarchive' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_newsarchive' class='SubmenuitemLabel'>News Archive</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/abouttibia/?subtopic=screenshots">
+  <div id="submenu_screenshots" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_screenshots" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_screenshots" class="SubmenuitemLabel">Screenshots</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/news/?subtopic=eventcalendar'>
-<div id='submenu_eventcalendar' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_eventcalendar' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_eventcalendar' class='SubmenuitemLabel'>Event Schedule</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/abouttibia/?subtopic=gamefeatures">
+  <div id="submenu_gamefeatures" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_gamefeatures" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_gamefeatures" class="SubmenuitemLabel">Game Features</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/abouttibia/?subtopic=premiumfeatures">
+  <div id="submenu_premiumfeatures" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_premiumfeatures" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_premiumfeatures" class="SubmenuitemLabel">Premium Features</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/abouttibia/?subtopic=aboutcipsoft">
+  <div id="submenu_aboutcipsoft" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_aboutcipsoft" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_aboutcipsoft" class="SubmenuitemLabel">About CipSoft</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
 </div>
 </div>
-<div id='abouttibia' class='menuitem'>
-<span onClick="MenuItemAction('abouttibia')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='abouttibia_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
+<div id="gameguides" class="menuitem">
+<span onclick="MenuItemAction('gameguides')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="gameguides_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="gameguides_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-gameguides.gif);"></div>
+      <div id="gameguides_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-gameguides.png);"></div>
+      <div id="gameguides_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='abouttibia_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-abouttibia.gif);'></div>
-<div id='abouttibia_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-abouttibia.png);'></div>
-<div id='abouttibia_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
+<div id="gameguides_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/gameguides/?subtopic=quickstart">
+  <div id="submenu_quickstart" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_quickstart" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_quickstart" class="SubmenuitemLabel">Quickstart</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/gameguides/?subtopic=manual">
+  <div id="submenu_manual" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_manual" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_manual" class="SubmenuitemLabel">Manual</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/gameguides/?subtopic=securityhints">
+  <div id="submenu_securityhints" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_securityhints" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_securityhints" class="SubmenuitemLabel">Security Hints</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
 </div>
 </div>
+<div id="library" class="menuitem">
+<span onclick="MenuItemAction('library')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="library_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="library_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-library.gif);"></div>
+      <div id="library_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-library.png);"></div>
+      <div id="library_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='abouttibia_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/abouttibia/?subtopic=whatistibia'>
-<div id='submenu_whatistibia' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_whatistibia' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_whatistibia' class='SubmenuitemLabel'>What Is Tibia?</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<div id="library_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/library/?subtopic=creatures">
+  <div id="submenu_creatures" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_creatures" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_creatures" class="SubmenuitemLabel">Creatures</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/abouttibia/?subtopic=screenshots'>
-<div id='submenu_screenshots' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_screenshots' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_screenshots' class='SubmenuitemLabel'>Screenshots</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/library/?subtopic=boostablebosses">
+  <div id="submenu_boostablebosses" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)" style="color: white;">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_boostablebosses" class="ActiveSubmenuItemIcon" style="background-image: url(&quot;https://static.tibia.com/images/global/menu/icon-activesubmenu.gif&quot;); visibility: visible;"></div>
+    <div id="ActiveSubmenuItemLabel_boostablebosses" class="SubmenuitemLabel">Boostable Bosses</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/abouttibia/?subtopic=gamefeatures'>
-<div id='submenu_gamefeatures' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_gamefeatures' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_gamefeatures' class='SubmenuitemLabel'>Game Features</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/library/?subtopic=spells">
+  <div id="submenu_spells" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_spells" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_spells" class="SubmenuitemLabel">Spells</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/abouttibia/?subtopic=premiumfeatures'>
-<div id='submenu_premiumfeatures' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_premiumfeatures' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_premiumfeatures' class='SubmenuitemLabel'>Premium Features</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/library/?subtopic=achievements">
+  <div id="submenu_achievements" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_achievements" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_achievements" class="SubmenuitemLabel">Achievements</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/abouttibia/?subtopic=aboutcipsoft'>
-<div id='submenu_aboutcipsoft' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_aboutcipsoft' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_aboutcipsoft' class='SubmenuitemLabel'>About CipSoft</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/library/?subtopic=worldquests">
+  <div id="submenu_worldquests" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_worldquests" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_worldquests" class="SubmenuitemLabel">World Quests</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/library/?subtopic=experiencetable">
+  <div id="submenu_experiencetable" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_experiencetable" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_experiencetable" class="SubmenuitemLabel">Experience Table</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/library/?subtopic=maps">
+  <div id="submenu_maps" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_maps" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_maps" class="SubmenuitemLabel">Maps</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/library/?subtopic=genesis">
+  <div id="submenu_genesis" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_genesis" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_genesis" class="SubmenuitemLabel">Genesis</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/library/?subtopic=soundtrack">
+  <div id="submenu_soundtrack" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_soundtrack" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_soundtrack" class="SubmenuitemLabel">Soundtrack</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
 </div>
 </div>
-<div id='gameguides' class='menuitem'>
-<span onClick="MenuItemAction('gameguides')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='gameguides_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
+<div id="community" class="menuitem">
+<span onclick="MenuItemAction('community')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="community_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="community_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-community.gif);"></div>
+      <div id="community_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-community.png);"></div>
+      <div id="community_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='gameguides_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-gameguides.gif);'></div>
-<div id='gameguides_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-gameguides.png);'></div>
-<div id='gameguides_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
+<div id="community_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/community/?subtopic=characters">
+  <div id="submenu_characters" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_characters" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_characters" class="SubmenuitemLabel">Characters</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=worlds">
+  <div id="submenu_worlds" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_worlds" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_worlds" class="SubmenuitemLabel">Worlds</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=highscores">
+  <div id="submenu_highscores" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_highscores" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_highscores" class="SubmenuitemLabel">Highscores</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=leaderboards">
+  <div id="submenu_leaderboards" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_leaderboards" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_leaderboards" class="SubmenuitemLabel">Leaderboards</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=wheelofdestinyplanner">
+  <div id="submenu_wheelofdestinyplanner" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_wheelofdestinyplanner" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_wheelofdestinyplanner" class="SubmenuitemLabel">Wheel of Destiny Planner</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=killstatistics">
+  <div id="submenu_killstatistics" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_killstatistics" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_killstatistics" class="SubmenuitemLabel">Kill Statistics</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=houses">
+  <div id="submenu_houses" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_houses" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_houses" class="SubmenuitemLabel">Houses</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=guilds">
+  <div id="submenu_guilds" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_guilds" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_guilds" class="SubmenuitemLabel">Guilds</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=polls">
+  <div id="submenu_polls" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_polls" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_polls" class="SubmenuitemLabel">Polls</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=feedbackform">
+  <div id="submenu_feedbackform" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_feedbackform" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_feedbackform" class="SubmenuitemLabel">Feedback Form</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=fansites">
+  <div id="submenu_fansites" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_fansites" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_fansites" class="SubmenuitemLabel">Fansites</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/community/?subtopic=resellers">
+  <div id="submenu_resellers" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_resellers" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_resellers" class="SubmenuitemLabel">Resellers</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
 </div>
 </div>
+<div id="forum" class="menuitem">
+<span onclick="MenuItemAction('forum')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="forum_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="forum_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-forum.gif);"></div>
+      <div id="forum_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-forum.png);"></div>
+      <div id="forum_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='gameguides_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/gameguides/?subtopic=quickstart'>
-<div id='submenu_quickstart' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_quickstart' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_quickstart' class='SubmenuitemLabel'>Quickstart</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<div id="forum_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/forum/?subtopic=worldboards">
+  <div id="submenu_worldboards" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_worldboards" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_worldboards" class="SubmenuitemLabel">World Boards</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/gameguides/?subtopic=manual'>
-<div id='submenu_manual' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_manual' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_manual' class='SubmenuitemLabel'>Manual</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/forum/?subtopic=tradeboards">
+  <div id="submenu_tradeboards" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_tradeboards" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_tradeboards" class="SubmenuitemLabel">Trade Boards</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/gameguides/?subtopic=securityhints'>
-<div id='submenu_securityhints' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_securityhints' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_securityhints' class='SubmenuitemLabel'>Security Hints</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/forum/?subtopic=communityboards">
+  <div id="submenu_communityboards" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_communityboards" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_communityboards" class="SubmenuitemLabel">Community Boards</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/forum/?subtopic=supportboards">
+  <div id="submenu_supportboards" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_supportboards" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_supportboards" class="SubmenuitemLabel">Support Boards</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/forum/?subtopic=guildboards">
+  <div id="submenu_guildboards" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_guildboards" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_guildboards" class="SubmenuitemLabel">Guild Boards</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/forum/?subtopic=forum&amp;action=cm_post_archive">
+  <div id="submenu_forum" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_forum" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_forum" class="SubmenuitemLabel">CM Post Archive</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
 </div>
 </div>
-<div id='library' class='menuitem'>
-<span onClick="MenuItemAction('library')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='library_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
+<div id="account" class="menuitem">
+<span onclick="MenuItemAction('account')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="account_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="account_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-account.gif);"></div>
+      <div id="account_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-account.png);"></div>
+      <div id="account_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='library_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-library.gif);'></div>
-<div id='library_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-library.png);'></div>
-<div id='library_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
+<div id="account_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/account/?subtopic=accountmanagement&amp;page=overview">
+  <div id="submenu_accountmanagement" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_accountmanagement" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_accountmanagement" class="SubmenuitemLabel">Account Management</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/account/?subtopic=createaccount">
+  <div id="submenu_createaccount" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_createaccount" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_createaccount" class="SubmenuitemLabel">Create Account</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/account/?subtopic=downloadclient&amp;step=downloadagreement">
+  <div id="submenu_downloadclient" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_downloadclient" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_downloadclient" class="SubmenuitemLabel">Download Client</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/account/index.php?subtopic=redirectlogin&amp;redirect=https%3A%2F%2Fwww.tibia.com%2Faccount%2F%3Fsubtopic%3Daccountmanagement%23Products%2BAvailable">
+  <div id="submenu_webshop" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_webshop" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_webshop" class="SubmenuitemLabel">Webshop</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
+<a href="https://www.tibia.com/account/?subtopic=lostaccount">
+  <div id="submenu_lostaccount" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_lostaccount" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_lostaccount" class="SubmenuitemLabel">Lost Account</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
+</a>
 </div>
 </div>
+<div id="charactertrade" class="menuitem">
+<span onclick="MenuItemAction('charactertrade')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="charactertrade_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="charactertrade_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-charactertrade.gif);"></div>
+      <div id="charactertrade_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-charactertrade.png);"></div>
+      <div id="charactertrade_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='library_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/library/?subtopic=creatures'>
-<div id='submenu_creatures' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_creatures' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_creatures' class='SubmenuitemLabel'>Creatures</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<div id="charactertrade_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/charactertrade/?subtopic=currentcharactertrades">
+  <div id="submenu_currentcharactertrades" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_currentcharactertrades" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_currentcharactertrades" class="SubmenuitemLabel">Current Auctions</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/library/?subtopic=boostablebosses'>
-<div id='submenu_boostablebosses' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_boostablebosses' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_boostablebosses' class='SubmenuitemLabel'>Boostable Bosses</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/charactertrade/?subtopic=pastcharactertrades">
+  <div id="submenu_pastcharactertrades" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_pastcharactertrades" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_pastcharactertrades" class="SubmenuitemLabel">Auction History</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/library/?subtopic=spells'>
-<div id='submenu_spells' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_spells' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_spells' class='SubmenuitemLabel'>Spells</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/charactertrade/?subtopic=ownbids">
+  <div id="submenu_ownbids" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_ownbids" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_ownbids" class="SubmenuitemLabel">My Bids</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/library/?subtopic=achievements'>
-<div id='submenu_achievements' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_achievements' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_achievements' class='SubmenuitemLabel'>Achievements</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/charactertrade/?subtopic=owncharactertrades">
+  <div id="submenu_owncharactertrades" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_owncharactertrades" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_owncharactertrades" class="SubmenuitemLabel">My Auctions</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/library/?subtopic=worldquests'>
-<div id='submenu_worldquests' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_worldquests' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_worldquests' class='SubmenuitemLabel'>World Quests</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/library/?subtopic=experiencetable'>
-<div id='submenu_experiencetable' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_experiencetable' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_experiencetable' class='SubmenuitemLabel'>Experience Table</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/library/?subtopic=maps'>
-<div id='submenu_maps' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_maps' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_maps' class='SubmenuitemLabel'>Maps</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/library/?subtopic=genesis'>
-<div id='submenu_genesis' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_genesis' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_genesis' class='SubmenuitemLabel'>Genesis</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/charactertrade/?subtopic=watchedcharactertrades">
+  <div id="submenu_watchedcharactertrades" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_watchedcharactertrades" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_watchedcharactertrades" class="SubmenuitemLabel">My Watched Auctions</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
 </div>
 </div>
-<div id='community' class='menuitem'>
-<span onClick="MenuItemAction('community')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='community_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
+<div id="support" class="menuitem">
+<span onclick="MenuItemAction('support')">
+  <div class="MenuButton" style="background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);">
+    <div onmouseover="MouseOverMenuItem(this);" onmouseout="MouseOutMenuItem(this);"><div class="Button" style="background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);"></div>
+      <span id="support_Lights" class="Lights" style="visibility: visible;">
+        <div class="light_lu" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ld" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+        <div class="light_ru" style="background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);"></div>
+      </span>
+      <div id="support_Icon" class="Icon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-support.gif);"></div>
+      <div id="support_Label" class="Label" style="background-image:url(https://static.tibia.com/images/global/menu/label-support.png);"></div>
+      <div id="support_Extend" class="Extend" style="background-image:url(https://static.tibia.com/images/global/general/plus.gif);"></div>
+    </div>
+  </div>
 </span>
-<div id='community_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-community.gif);'></div>
-<div id='community_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-community.png);'></div>
-<div id='community_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
-</div>
-</div>
-</span>
-<div id='community_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/community/?subtopic=characters'>
-<div id='submenu_characters' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_characters' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_characters' class='SubmenuitemLabel'>Characters</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<div id="support_Submenu" class="Submenu" style="visibility: hidden; display: none;">
+<a href="https://www.tibia.com/support/?subtopic=gethelp">
+  <div id="submenu_gethelp" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_gethelp" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_gethelp" class="SubmenuitemLabel">FAQ</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/community/?subtopic=worlds'>
-<div id='submenu_worlds' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_worlds' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_worlds' class='SubmenuitemLabel'>Worlds</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/support/?subtopic=tibiarules">
+  <div id="submenu_tibiarules" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_tibiarules" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_tibiarules" class="SubmenuitemLabel">Tibia Rules</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/community/?subtopic=tournament'>
-<div id='submenu_tournament' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_tournament' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_tournament' class='SubmenuitemLabel'>Tournaments</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/support/?subtopic=parentsguide">
+  <div id="submenu_parentsguide" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_parentsguide" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_parentsguide" class="SubmenuitemLabel">Parents' Guide</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
-<a href='https://www.tibia.com/community/?subtopic=highscores'>
-<div id='submenu_highscores' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_highscores' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_highscores' class='SubmenuitemLabel'>Highscores</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=pantheonhighscore'>
-<div id='submenu_pantheonhighscore' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_pantheonhighscore' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_pantheonhighscore' class='SubmenuitemLabel'>Pantheon Highscore</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=leaderboards'>
-<div id='submenu_leaderboards' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_leaderboards' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_leaderboards' class='SubmenuitemLabel'>Leaderboards</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=tournamentleaderboards'>
-<div id='submenu_tournamentleaderboards' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_tournamentleaderboards' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_tournamentleaderboards' class='SubmenuitemLabel'>Tournament Leaderboards</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=killstatistics'>
-<div id='submenu_killstatistics' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_killstatistics' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_killstatistics' class='SubmenuitemLabel'>Kill Statistics</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=houses'>
-<div id='submenu_houses' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_houses' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_houses' class='SubmenuitemLabel'>Houses</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=guilds'>
-<div id='submenu_guilds' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_guilds' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_guilds' class='SubmenuitemLabel'>Guilds</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=polls'>
-<div id='submenu_polls' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_polls' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_polls' class='SubmenuitemLabel'>Polls</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=feedbackform'>
-<div id='submenu_feedbackform' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_feedbackform' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_feedbackform' class='SubmenuitemLabel'>Feedback Form</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=fansites'>
-<div id='submenu_fansites' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_fansites' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_fansites' class='SubmenuitemLabel'>Fansites</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/community/?subtopic=resellers'>
-<div id='submenu_resellers' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_resellers' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_resellers' class='SubmenuitemLabel'>Resellers</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
+<a href="https://www.tibia.com/support/?subtopic=legaldocuments">
+  <div id="submenu_legaldocuments" class="Submenuitem" onmouseover="MouseOverSubmenuItem(this)" onmouseout="MouseOutSubmenuItem(this)">
+    <div class="LeftChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+    <div id="ActiveSubmenuItemIcon_legaldocuments" class="ActiveSubmenuItemIcon" style="background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);"></div>
+    <div id="ActiveSubmenuItemLabel_legaldocuments" class="SubmenuitemLabel">Legal Documents</div>
+    <div class="RightChain" style="background-image:url(https://static.tibia.com/images/global/general/chain.gif);"></div>
+  </div>
 </a>
 </div>
 </div>
-<div id='forum' class='menuitem'>
-<span onClick="MenuItemAction('forum')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='forum_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-</span>
-<div id='forum_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-forum.gif);'></div>
-<div id='forum_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-forum.png);'></div>
-<div id='forum_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
-</div>
-</div>
-</span>
-<div id='forum_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/forum/?subtopic=worldboards'>
-<div id='submenu_worldboards' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_worldboards' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_worldboards' class='SubmenuitemLabel'>World Boards</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/forum/?subtopic=tradeboards'>
-<div id='submenu_tradeboards' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_tradeboards' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_tradeboards' class='SubmenuitemLabel'>Trade Boards</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/forum/?subtopic=communityboards'>
-<div id='submenu_communityboards' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_communityboards' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_communityboards' class='SubmenuitemLabel'>Community Boards</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/forum/?subtopic=supportboards'>
-<div id='submenu_supportboards' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_supportboards' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_supportboards' class='SubmenuitemLabel'>Support Boards</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/forum/?subtopic=guildboards'>
-<div id='submenu_guildboards' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_guildboards' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_guildboards' class='SubmenuitemLabel'>Guild Boards</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/forum/?subtopic=forum&action=cm_post_archive'>
-<div id='submenu_forum' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_forum' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_forum' class='SubmenuitemLabel'>CM Post Archive</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-</div>
-</div>
-<div id='account' class='menuitem'>
-<span onClick="MenuItemAction('account')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='account_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-</span>
-<div id='account_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-account.gif);'></div>
-<div id='account_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-account.png);'></div>
-<div id='account_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
-</div>
-</div>
-</span>
-<div id='account_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/account/?subtopic=accountmanagement&amp;page=overview'>
-<div id='submenu_accountmanagement' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_accountmanagement' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_accountmanagement' class='SubmenuitemLabel'>Account Management</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/account/?subtopic=createaccount'>
-<div id='submenu_createaccount' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_createaccount' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_createaccount' class='SubmenuitemLabel'>Create Account</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/account/?subtopic=downloadclient&step=downloadagreement'>
-<div id='submenu_downloadclient' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_downloadclient' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_downloadclient' class='SubmenuitemLabel'>Download Client</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/account/index.php?subtopic=redirectlogin&redirect=https%3A%2F%2Fwww.tibia.com%2Faccount%2F%3Fsubtopic%3Daccountmanagement%23Products%2BAvailable'>
-<div id='submenu_webshop' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_webshop' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_webshop' class='SubmenuitemLabel'>Webshop</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/account/?subtopic=lostaccount'>
-<div id='submenu_lostaccount' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_lostaccount' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_lostaccount' class='SubmenuitemLabel'>Lost Account</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-</div>
-</div>
-<div id='charactertrade' class='menuitem'>
-<span onClick="MenuItemAction('charactertrade')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='charactertrade_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-</span>
-<div id='charactertrade_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-charactertrade.gif);'></div>
-<div id='charactertrade_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-charactertrade.png);'></div>
-<div id='charactertrade_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
-</div>
-</div>
-</span>
-<div id='charactertrade_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/charactertrade/?subtopic=currentcharactertrades'>
-<div id='submenu_currentcharactertrades' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_currentcharactertrades' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_currentcharactertrades' class='SubmenuitemLabel'>Current Auctions</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/charactertrade/?subtopic=pastcharactertrades'>
-<div id='submenu_pastcharactertrades' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_pastcharactertrades' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_pastcharactertrades' class='SubmenuitemLabel'>Auction History</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/charactertrade/?subtopic=ownbids'>
-<div id='submenu_ownbids' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_ownbids' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_ownbids' class='SubmenuitemLabel'>My Bids</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/charactertrade/?subtopic=owncharactertrades'>
-<div id='submenu_owncharactertrades' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_owncharactertrades' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_owncharactertrades' class='SubmenuitemLabel'>My Auctions</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/charactertrade/?subtopic=watchedcharactertrades'>
-<div id='submenu_watchedcharactertrades' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_watchedcharactertrades' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_watchedcharactertrades' class='SubmenuitemLabel'>My Watched Auctions</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-</div>
-</div>
-<div id='support' class='menuitem'>
-<span onClick="MenuItemAction('support')">
-<div class='MenuButton' style='background-image:url(https://static.tibia.com/images/global/menu/button-background.gif);'>
-<div onMouseOver='MouseOverMenuItem(this);' onMouseOut='MouseOutMenuItem(this);'><div class='Button' style='background-image:url(https://static.tibia.com/images/global/menu/button-background-over.gif);'></div>
-<span id='support_Lights' class='Lights'>
-<div class='light_lu' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ld' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-<div class='light_ru' style='background-image:url(https://static.tibia.com/images/global/menu/green-light.gif);'></div>
-</span>
-<div id='support_Icon' class='Icon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-support.gif);'></div>
-<div id='support_Label' class='Label' style='background-image:url(https://static.tibia.com/images/global/menu/label-support.png);'></div>
-<div id='support_Extend' class='Extend' style='background-image:url(https://static.tibia.com/images/global/general/plus.gif);'></div>
-</div>
-</div>
-</span>
-<div id='support_Submenu' class='Submenu'>
-<a href='https://www.tibia.com/support/?subtopic=gethelp'>
-<div id='submenu_gethelp' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_gethelp' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_gethelp' class='SubmenuitemLabel'>FAQ</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/support/?subtopic=tibiarules'>
-<div id='submenu_tibiarules' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_tibiarules' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_tibiarules' class='SubmenuitemLabel'>Tibia Rules</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/support/?subtopic=tutorguide'>
-<div id='submenu_tutorguide' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_tutorguide' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_tutorguide' class='SubmenuitemLabel'>Tutor Guide</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/support/?subtopic=parentsguide'>
-<div id='submenu_parentsguide' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_parentsguide' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_parentsguide' class='SubmenuitemLabel'>Parents' Guide</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-<a href='https://www.tibia.com/support/?subtopic=legaldocuments'>
-<div id='submenu_legaldocuments' class='Submenuitem' onMouseOver='MouseOverSubmenuItem(this)' onMouseOut='MouseOutSubmenuItem(this)'>
-<div class='LeftChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-<div id='ActiveSubmenuItemIcon_legaldocuments' class='ActiveSubmenuItemIcon' style='background-image:url(https://static.tibia.com/images/global/menu/icon-activesubmenu.gif);'></div>
-<div id='ActiveSubmenuItemLabel_legaldocuments' class='SubmenuitemLabel'>Legal Documents</div>
-<div class='RightChain' style='background-image:url(https://static.tibia.com/images/global/general/chain.gif);'></div>
-</div>
-</a>
-</div>
-</div>
-<div id='MenuBottom' style='background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif);'></div>
+<div id="MenuBottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif);"></div>
 </div>
 <script type="text/javascript">
 InitializePage();</script>
-</div>
-</div>
-<div class="main-content Content">
-<div id="" class="Box"><div class="Corner-tl" style="background-image:url(https://static.tibia.com/images/global/content/corner-tl.gif);"></div><div class="Corner-tr" style="background-image:url(https://static.tibia.com/images/global/content/corner-tr.gif);"></div><div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div><div class="BorderTitleText" style="background-image:url(https://static.tibia.com/images/global/content/newsheadline_background.gif); height: 28px;"><div class="InfoBar"><a class="InfoBarBlock" href="https://www.twitch.tv/directory/game/Tibia" target="_blank" rel="noopener noreferrer"><img class="InfoBarBigLogo" src="https://static.tibia.com/images/global/header/info/icon-twitch.png" /><span class="InfoBarNumbers"><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-streamers.png" /><span class="InfoBarSmallElement">197</span><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-viewers.png" /><span class="InfoBarSmallElement">4191</span></span></a><a class="InfoBarBlock" href="https://www.youtube.com/channel/UCg5vFOB3tN8KGcJDyk6QQzQ/home" target="_blank" rel="noopener noreferrer"><img class="InfoBarBigLogo" src="https://static.tibia.com/images/global/header/info/icon-youtube.png" /><span class="InfoBarNumbers"><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-streamers.png" /><span class="InfoBarSmallElement">2</span><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-viewers.png" /><span class="InfoBarSmallElement">1</span></span></a><a href="https://www.tibia.com/forum/?action=announcement&announcementid=87&boardid=89516"><img class="InfoBarBigLogo" src="https://static.tibia.com/images/global/header/info/icon-download.png" /><span class="InfoBarNumbers"><span class="InfoBarSmallElement">Fankit</span></span></a><a style="float:right;" href="https://www.tibia.com/community/?subtopic=worlds"><img class="InfoBarBigLogo" src="https://static.tibia.com/images/global/header/info/icon-players-online.png" /><span class="InfoBarNumbers"><span class="InfoBarSmallElement">11,497 Players Online</span></span></a></div></div><div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div><div class="CornerWrapper-b"><div class="Corner-bl" style="background-image:url(https://static.tibia.com/images/global/content/corner-bl.gif);"></div></div><div class="CornerWrapper-b"><div class="Corner-br" style="background-image:url(https://static.tibia.com/images/global/content/corner-br.gif);"></div></div></div> <div id="RightArtwork">
-<img id="Pedestal" src="https://static.tibia.com/images/global/header/pedestal.gif" alt="Monster Pedestal Box" /><br><img id="Monster" title="Today's boosted creature: Menacing Carnivor" src="https://static.tibia.com/images/global/header/monsters/menacingcarnivor.gif" onClick="window.location = 'https://www.tibia.com/library/?subtopic=creatures';" alt="Boosted Creature" /><img id="Boss" title="Today's boosted boss: Tentugly" src="https://static.tibia.com/images/global/header/monsters/fakeseamonster.gif" onClick="window.location = 'https://www.tibia.com/library/?subtopic=boostablebosses';" alt="Boosted Boss" /> </div>
-<div id="boostablebosses" class="Box">
-<div class="Corner-tl" style="background-image:url(https://static.tibia.com/images/global/content/corner-tl.gif);"></div>
-<div class="Corner-tr" style="background-image:url(https://static.tibia.com/images/global/content/corner-tr.gif);"></div>
-<div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div>
-<div class="BorderTitleText" style="background-image:url(https://static.tibia.com/images/global/content/title-background-green.gif);"></div><img id="ContentBoxHeadline" class="Title" src="https://static.tibia.com/images/global/strings/headline-boostablebosses.gif" alt="Contentbox headline" />
-<div class="Border_2">
-<div class="Border_3">
-<div class="BoxContent" style="background-image:url(https://static.tibia.com/images/global/content/scroll.gif);">
-<div class="TableContainer"> <table class="Table1" cellpadding="0" cellspacing="0"> <div class="CaptionContainer"> <div class="CaptionInnerContainer"> <span class="CaptionEdgeLeftTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);" /></span> <span class="CaptionEdgeRightTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);" /></span> <span class="CaptionBorderTop" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span> <span class="CaptionVerticalLeft" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);" /></span> <div class="Text">Boosted Boss</div> <span class="CaptionVerticalRight" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);" /></span> <span class="CaptionBorderBottom" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span> <span class="CaptionEdgeLeftBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);" /></span> <span class="CaptionEdgeRightBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);" /></span> </div> </div> <tr> <td> <div class="InnerTableContainer"> <table style="width:100%;"><p><img src="https://static.tibia.com/images/global/header/monsters/fakeseamonster.gif" style="float:right" />Today's boosted boss: <b>Tentugly</b></p><p>Defeating a boosted boss is extra lucrative. Boosted bosses contain more loot and count more kills for your Bosstiary.</p> </table> </div> </td> </tr> </table></div><br /><div style="display: table; width: 100%; "> <div class="Creatures" style="text-align:center; "> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/abyssador.gif" border=0 /> <div>Abyssador</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/ameneftheburning.gif" border=0 /> <div>Amenef The Burning</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/anomaly.gif" border=0 /> <div>Anomaly</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/vixen.gif" border=0 /> <div>Black Vixen</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/bloodhoof.gif" border=0 /> <div>Bloodback</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/brainhead.gif" border=0 /> <div>Brain Head</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/brokul.gif" border=0 /> <div>Brokul</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/countvlarkort.gif" border=0 /> <div>Count Vlarkorth</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/darkfang.gif" border=0 /> <div>Darkfang</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/deathstrike.gif" border=0 /> <div>Deathstrike</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/drume.gif" border=0 /> <div>Drume</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/dukekrule.gif" border=0 /> <div>Duke Krule</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/earlosam.gif" border=0 /> <div>Earl Osam</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/ekatrix.gif" border=0 /> <div>Ekatrix</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/eradicator.gif" border=0 /> <div>Eradicator</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/essenceofmalice.gif" border=0 /> <div>Essence Of Malice</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/facelessbane.gif" border=0 /> <div>Faceless Bane</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/ghulosh.gif" border=0 /> <div>Ghulosh</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/gnomehorticulist.gif" border=0 /> <div>Gnomevil</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/gorzindel.gif" border=0 /> <div>Gorzindel</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/goshnarscruelty.gif" border=0 /> <div>Goshnar's Cruelty</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/goshnarsgreed.gif" border=0 /> <div>Goshnar's Greed</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/goshnarshatred.gif" border=0 /> <div>Goshnar's Hatred</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/goshnarsmalice.gif" border=0 /> <div>Goshnar's Malice</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/goshnarsspite.gif" border=0 /> <div>Goshnar's Spite</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/grandmasteroberon.gif" border=0 /> <div>Grand Master Oberon</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/irgix.gif" border=0 /> <div>Irgix The Flimsy</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/katex.gif" border=0 /> <div>Katex Blood Tongue</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/kingzelos.gif" border=0 /> <div>King Zelos</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/kusuma.gif" border=0 /> <div>Kusuma</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/ladytenebris.gif" border=0 /> <div>Lady Tenebris</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/lloyd.gif" border=0 /> <div>Lloyd</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/lokathmor.gif" border=0 /> <div>Lokathmor</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/lordazaram.gif" border=0 /> <div>Lord Azaram</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/lordretro.gif" border=0 /> <div>Lord Retro</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/magmacolossus.gif" border=0 /> <div>Magma Bubble</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/mazoran.gif" border=0 /> <div>Mazoran</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/mazzinor.gif" border=0 /> <div>Mazzinor</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/yselda.gif" border=0 /> <div>Megasylvan Yselda</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/neferithespy.gif" border=0 /> <div>Neferi The Spy</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/outburst.gif" border=0 /> <div>Outburst</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/plagirath.gif" border=0 /> <div>Plagirath</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/ragiaz.gif" border=0 /> <div>Ragiaz</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/ratmiral.gif" border=0 /> <div>Ratmiral Blackwhiskers</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/ravenoushunger.gif" border=0 /> <div>Ravenous Hunger</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/razzargorn.gif" border=0 /> <div>Razzagorn</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/realityquake.gif" border=0 /> <div>Realityquake</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/rupture.gif" border=0 /> <div>Rupture</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/scarlettetzelstill.gif" border=0 /> <div>Scarlett Etzel</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/blackpelt.gif" border=0 /> <div>Shadowpelt</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/sharpclaw.gif" border=0 /> <div>Sharpclaw</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/shulgrax.gif" border=0 /> <div>Shulgrax</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/sirbaeloc.gif" border=0 /> <div>Sir Baeloc</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/sirnictros.gif" border=0 /> <div>Sir Nictros</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/sisterhetai.gif" border=0 /> <div>Sister Hetai</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/dragonkingzyrtrachkillable.gif" border=0 /> <div>Soul Of Dragonking Zyrtarch</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/srezz.gif" border=0 /> <div>Srezz Yellow Eyes</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/tarbaz.gif" border=0 /> <div>Tarbaz</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/fakeseamonster.gif" border=0 /> <div>Tentugly</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/thaian.gif" border=0 /> <div>Thaian</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/blazingrose.gif" border=0 /> <div>The Blazing Rose</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/brainstealer.gif" border=0 /> <div>The Brainstealer</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/diamondblossom.gif" border=0 /> <div>The Diamond Blossom</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/dreadmaiden.gif" border=0 /> <div>The Dread Maiden</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/thornknight.gif" border=0 /> <div>The Enraged Thorn Knight</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/falsegod.gif" border=0 /> <div>The False God</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/fearfeaster.gif" border=0 /> <div>The Fear Feaster</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/flamingorchid.gif" border=0 /> <div>The Flaming Orchid</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/lilyofnight.gif" border=0 /> <div>The Lily Of Night</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/megamagmaoid.gif" border=0 /> <div>The Mega Magmaoid</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/moonlightaster.gif" border=0 /> <div>The Moonlight Aster</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/nightmarebeast.gif" border=0 /> <div>The Nightmare Beast</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/paleworm.gif" border=0 /> <div>The Pale Worm</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/sandkingfinal.gif" border=0 /> <div>The Sandking</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/scourgeofoblivion00.gif" border=0 /> <div>The Scourge Of Oblivion</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/souldespoiler.gif" border=0 /> <div>The Souldespoiler</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/sourceofcorruption.gif" border=0 /> <div>The Source Of Corruption</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/timeguardian.gif" border=0 /> <div>The Time Guardian</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/voidbornvulnerable.gif" border=0 /> <div>The Unarmored Voidborn</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/theunwelcome.gif" border=0 /> <div>The Unwelcome</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/winterbloom.gif" border=0 /> <div>The Winter Bloom</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/timira.gif" border=0 /> <div>Timira The Many-Headed</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/unaz.gif" border=0 /> <div>Unaz The Mean</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/urmahlulluweakest.gif" border=0 /> <div>Urmahlullu The Weakened</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/utua.gif" border=0 /> <div>Utua Stone Sting</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/vok.gif" border=0 /> <div>Vok The Freakish</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/yirkass.gif" border=0 /> <div>Yirkas Blue Scales</div> </div> <div style="width: 100px; height: 110px; margin: 0px; float: left;"> <img src="https://static.tibia.com/images/library/zamulosh.gif" border=0 /> <div>Zamulosh</div> </div> </div></div> </div>
-</div>
-</div>
-<div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div>
-<div class="CornerWrapper-b"><div class="Corner-bl" style="background-image:url(https://static.tibia.com/images/global/content/corner-bl.gif);"></div></div>
-<div class="CornerWrapper-b"><div class="Corner-br" style="background-image:url(https://static.tibia.com/images/global/content/corner-br.gif);"></div></div>
-</div>
-<div id="Footer" class="main-footer">
-Copyright by CipSoft GmbH. All rights reserved.<br />
-<a href="https://www.tibia.com/abouttibia/?subtopic=aboutcipsoft">About CipSoft</a> | <a href="https://www.tibia.com/support/?subtopic=legaldocuments&amp;page=agreement">Service Agreement</a> | <a href="https://www.tibia.com/support/?subtopic=legaldocuments&amp;page=privacy">Privacy Policy</a>
-</div>
-</div>
-<div class="main-themboxes Themeboxes">
-<div id="DeactivationContainerThemebox" onClick="StopVideoIfExists();DisableDeactivationContainer();"></div>
-<div id="PremiumBox" class="Themebox" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/themebox.png);"><div id="PremiumBoxDecor" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/crown_animation.gif);"></div><div id="PremiumBoxBg" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/premium_offline_training.png);"></div><div id="PremiumBoxOverlay" style="background-image:url(https://static.tibia.com/images//global/themeboxes/premium/type_overlay.png);"><p id="PremiumBoxOverlayText">Train Skills Offline!</p></div><div id="PremiumBoxButton"><form action="https://www.tibia.com/account/index.php?subtopic=redirectlogin&redirect=https%3A%2F%2Fwww.tibia.com%2Faccount%2F%3Fsubtopic%3Daccountmanagement%23Products%2BAvailable" method="post" style="padding:0px;margin:0px;"><div class="WebshopButton" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/button.png)"><div onMouseOver="MouseOverWebshopButton(this);" onMouseOut="MouseOutWebshopButton(this);"><div class="WebshopButtonOver" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/button_hover.png);"></div><input class="WebshopButtonText" type="image" name="Get Premium" alt="Get Premium" src="https://static.tibia.com/images/global/themeboxes/premium/get_premium.png"></div></div></form></div><div id="PremiumBoxButtonDecor" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/button_premiumtime.png);"></div></div> <div id="NetworksBox" class="Themebox" style="background-image:url(https://static.tibia.com/images/global/themeboxes/networks/networksbox.png);">
-<div id="FacebookBlock">
-<a id="FacebookPageLink" target="_blank" href="https://www.facebook.com/tibia" rel="noopener noreferrer"><img src="https://static.tibia.com/images/global/themeboxes/networks/tibia-facebook-page-logo.png" /></a>
-<div id="FacebookLikeButton">
-<div class="fb-like" data-href="https://www.facebook.com/tibia" data-layout="button" data-action="like" data-show-faces="false" data-share="false"></div>
-</div>
-<div id="FacebookShareButton">
-<div class="fb-share-button" data-href="https://www.facebook.com/tibia" data-layout="button"></div>
-</div>
-<div id="FacebookLikes">
-<div class="fb-like" data-href="https://www.facebook.com/tibia" data-width="255" data-layout="standard" data-action="recommend" data-show-faces="false"></div>
-</div>
-</div>
-<div id="TwitterBlock">
-<a href="https://twitter.com/Tibia" class="twitter-follow-button" data-show-count="false">Follow @Tibia</a>
-<script>
-        ! function(d, s, id) {
-          var js, fjs = d.getElementsByTagName(s)[0],
-            p = /^http:/.test(d.location) ? 'http' : 'https';
-          if (!d.getElementById(id)) {
-            js = d.createElement(s);
-            js.id = id;
-            js.src = p + '://platform.twitter.com/widgets.js';
-            fjs.parentNode.insertBefore(js, fjs);
-          }
-        }(document, 'script', 'twitter-wjs');
-      </script>
-</div>
-<div class="Bottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif);"></div>
-</div>
+      </div>
+    </div>
+    <div class="main-content Content">
+      <div id="" class="Box"><div class="Corner-tl" style="background-image:url(https://static.tibia.com/images/global/content/corner-tl.gif);"></div><div class="Corner-tr" style="background-image:url(https://static.tibia.com/images/global/content/corner-tr.gif);"></div><div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div><div class="BorderTitleText" style="background-image:url(https://static.tibia.com/images/global/content/cacheinfo_background.gif); height: 28px;"><div class="InfoBar"><a class="InfoBarBlock" href="https://www.twitch.tv/directory/game/Tibia" target="_blank" rel="noopener noreferrer"><img class="InfoBarBigLogo NotOnMobile" src="https://static.tibia.com/images/global/header/info/icon-twitch.png"><img class="InfoBarSmallLogo" src="https://static.tibia.com/images/global/header/info/icon-mobile-twitch.png"><span class="InfoBarNumbers"><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-streamers.png"><span class="InfoBarSmallElement">231</span><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-viewers.png"><span class="InfoBarSmallElement">3983</span></span></a><a class="InfoBarBlock" href="https://www.youtube.com/channel/UCg5vFOB3tN8KGcJDyk6QQzQ/home" target="_blank" rel="noopener noreferrer"><img class="InfoBarBigLogo NotOnMobile" src="https://static.tibia.com/images/global/header/info/icon-youtube.png"><img class="InfoBarSmallLogo" src="https://static.tibia.com/images/global/header/info/icon-mobile-youtube.png"><span class="InfoBarNumbers"><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-streamers.png"><span class="InfoBarSmallElement">19</span><img class="InfoBarSmallElement" src="https://static.tibia.com/images/global/header/info/icon-viewers.png"><span class="InfoBarSmallElement">249</span></span></a><a class="NotOnMobile" href="https://www.tibia.com/forum/?action=announcement&amp;announcementid=87&amp;boardid=89516"><img class="InfoBarBigLogo" src="https://static.tibia.com/images/global/header/info/icon-download.png"><span class="InfoBarNumbers"><span class="InfoBarSmallElement">Fankit</span></span></a><a style="float:right;" href="https://www.tibia.com/community/?subtopic=worlds"><img class="InfoBarBigLogo" src="https://static.tibia.com/images/global/header/info/icon-players-online.png"><span class="InfoBarNumbers"><span class="InfoBarSmallElement">15,848<span class="NotOnMobile"> Players Online</span></span></span></a></div></div><div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div><div class="CornerWrapper-b"><div class="Corner-bl" style="background-image:url(https://static.tibia.com/images/global/content/corner-bl.gif);"></div></div><div class="CornerWrapper-b"><div class="Corner-br" style="background-image:url(https://static.tibia.com/images/global/content/corner-br.gif);"></div></div></div>      <div id="RightArtwork">
+        <img id="Pedestal" src="https://static.tibia.com/images/global/header/pedestal.gif" alt="Monster Pedestal Box"><br><img id="Monster" title="Today's boosted creature: War Wolf" src="https://static.tibia.com/images/global/header/monsters/warwolf.gif" onclick="window.location = 'https://www.tibia.com/library/?subtopic=creatures';" alt="Boosted Creature"><img id="Boss" title="Today's boosted boss: Abyssador" src="https://static.tibia.com/images/global/header/monsters/abyssador.gif" onclick="window.location = 'https://www.tibia.com/library/?subtopic=boostablebosses';" alt="Boosted Boss">      </div>
 
-<div id="FansiteBox" class="Themebox" style="background-image:url(https://static.tibia.com/images/global/themeboxes/fansites/fansites_themebox.gif);">
-<div id="FansiteLogoFrame" style="background-image:url(https://static.tibia.com/images/global/themeboxes/fansites/border_promoted.gif);">
-<a href="https://tibiaevents.com" target="_blank" rel="noopener noreferrer"><img id="FansiteLogo" src="https://static.tibia.com/images/community/fansitelogos/TibiaEvents.com.gif" /></a>
-</div>
-<div class="ThemeboxButton">
-<div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue.gif)"><div onMouseOver="MouseOverBigButton(this);" onMouseOut="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue_over.gif);"></div><a class="BigButtonText" href="https://www.tibia.com/community/?subtopic=fansites">View all Fansites</a></div></div> </div>
-<div class="Bottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif);"></div>
-</div>
-</div>
-</div>
-<script type="text/javascript">
+  <div id="boostablebosses" class="Box">
+    <div class="Corner-tl" style="background-image:url(https://static.tibia.com/images/global/content/corner-tl.gif);"></div>
+    <div class="Corner-tr" style="background-image:url(https://static.tibia.com/images/global/content/corner-tr.gif);"></div>
+    <div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div>
+    <div class="BorderTitleText" style="background-image:url(https://static.tibia.com/images/global/content/title-background-green.gif);"></div><img id="ContentBoxHeadline" class="Title" src="https://static.tibia.com/images/global/strings/headline-boostablebosses.gif" alt="Contentbox headline">
+    <div class="Border_2">
+      <div class="Border_3">
+        <div class="BoxContent" style="background-image:url(https://static.tibia.com/images/global/content/scroll.gif);">
+<div class="TableContainer">  <div class="CaptionContainer">      <div class="CaptionInnerContainer">        <span class="CaptionEdgeLeftTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionEdgeRightTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionBorderTop" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span>        <span class="CaptionVerticalLeft" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);"></span>        <div class="Text">Boosted Boss</div>        <span class="CaptionVerticalRight" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);"></span>        <span class="CaptionBorderBottom" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span>        <span class="CaptionEdgeLeftBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionEdgeRightBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>      </div>    </div><table class="Table1" cellpadding="0" cellspacing="0">        <tbody><tr>      <td>        <div class="InnerTableContainer">          <p><img src="https://static.tibia.com/images/global/header/monsters/abyssador.gif" style="float:right">Today's boosted boss: Abyssador</p><p>Defeating a boosted boss is extra lucrative. Boosted bosses contain more loot and count more kills for your Bosstiary.</p><table style="width:100%;">          </table>        </div>      </td>    </tr>  </tbody></table></div><br><div style="display: table; width: 100%; ">  <div class="Creatures" style="text-align:center; ">    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/abyssador.gif" border="0">      <div>Abyssador</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ahau.gif" border="0">      <div>Ahau</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ameneftheburning.gif" border="0">      <div>Amenef The Burning</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/anomaly.gif" border="0">      <div>Anomaly</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/arbaziloth4spheres.gif" border="0">      <div>Arbaziloth</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/vixen.gif" border="0">      <div>Black Vixen</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/bloodhoof.gif" border="0">      <div>Bloodback</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/brainhead.gif" border="0">      <div>Brain Head</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/brokul.gif" border="0">      <div>Brokul</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/chagorz.gif" border="0">      <div>Chagorz</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/countvlarkort.gif" border="0">      <div>Count Vlarkorth</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/darkfang.gif" border="0">      <div>Darkfang</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/deathstrike.gif" border="0">      <div>Deathstrike</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/representingdespor.gif" border="0">      <div>Dragon Pack</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/drume.gif" border="0">      <div>Drume</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/dukekrule.gif" border="0">      <div>Duke Krule</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/earlosam.gif" border="0">      <div>Earl Osam</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ekatrix.gif" border="0">      <div>Ekatrix</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/eradicator.gif" border="0">      <div>Eradicator</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/essenceofmalice.gif" border="0">      <div>Essence Of Malice</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/facelessbane.gif" border="0">      <div>Faceless Bane</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ghulosh.gif" border="0">      <div>Ghulosh</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/gnomehorticulist.gif" border="0">      <div>Gnomevil</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/gorzindel.gif" border="0">      <div>Gorzindel</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/goshnarscruelty.gif" border="0">      <div>Goshnar's Cruelty</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/goshnarsgreed.gif" border="0">      <div>Goshnar's Greed</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/goshnarshatred.gif" border="0">      <div>Goshnar's Hatred</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/goshnarsmalice.gif" border="0">      <div>Goshnar's Malice</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/goshnarsspite.gif" border="0">      <div>Goshnar's Spite</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/grandmasteroberon.gif" border="0">      <div>Grand Master Oberon</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ichgahal.gif" border="0">      <div>Ichgahal</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/irgix.gif" border="0">      <div>Irgix The Flimsy</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/katex.gif" border="0">      <div>Katex Blood Tongue</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/kingzelos.gif" border="0">      <div>King Zelos</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/kusuma.gif" border="0">      <div>Kusuma</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ladytenebris.gif" border="0">      <div>Lady Tenebris</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/lloyd.gif" border="0">      <div>Lloyd</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/lokathmor.gif" border="0">      <div>Lokathmor</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/lordazaram.gif" border="0">      <div>Lord Azaram</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/lordretro.gif" border="0">      <div>Lord Retro</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/magmacolossus.gif" border="0">      <div>Magma Bubble</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/mazoran.gif" border="0">      <div>Mazoran</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/mazzinor.gif" border="0">      <div>Mazzinor</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/yselda.gif" border="0">      <div>Megasylvan Yselda</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/frozenhorror.gif" border="0">      <div>Melting Frozen Horror</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/mitmahvanguard.gif" border="0">      <div>Mitmah Vanguard</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/murcion.gif" border="0">      <div>Murcion</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/neferithespy.gif" border="0">      <div>Neferi The Spy</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/outburst.gif" border="0">      <div>Outburst</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/plagirath.gif" border="0">      <div>Plagirath</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ragiaz.gif" border="0">      <div>Ragiaz</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ratmiral.gif" border="0">      <div>Ratmiral Blackwhiskers</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/ravenoushunger.gif" border="0">      <div>Ravenous Hunger</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/razzargorn.gif" border="0">      <div>Razzagorn</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/realityquake.gif" border="0">      <div>Realityquake</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/rupture.gif" border="0">      <div>Rupture</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/scarlettetzelstill.gif" border="0">      <div>Scarlett Etzel</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/blackpelt.gif" border="0">      <div>Shadowpelt</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/sharpclaw.gif" border="0">      <div>Sharpclaw</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/shulgrax.gif" border="0">      <div>Shulgrax</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/sirbaeloc.gif" border="0">      <div>Sir Baeloc</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/sirnictros.gif" border="0">      <div>Sir Nictros</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/sisterhetai.gif" border="0">      <div>Sister Hetai</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/dragonkingzyrtrachkillable.gif" border="0">      <div>Soul Of Dragonking Zyrtarch</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/srezz.gif" border="0">      <div>Srezz Yellow Eyes</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/tarbaz.gif" border="0">      <div>Tarbaz</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/fakeseamonster.gif" border="0">      <div>Tentugly</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/thaian.gif" border="0">      <div>Thaian</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/blazingrose.gif" border="0">      <div>The Blazing Rose</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/brainstealer.gif" border="0">      <div>The Brainstealer</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/diamondblossom.gif" border="0">      <div>The Diamond Blossom</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/dreadmaiden.gif" border="0">      <div>The Dread Maiden</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/thornknight.gif" border="0">      <div>The Enraged Thorn Knight</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/falsegod.gif" border="0">      <div>The False God</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/fearfeaster.gif" border="0">      <div>The Fear Feaster</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/flamingorchid.gif" border="0">      <div>The Flaming Orchid</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/lilyofnight.gif" border="0">      <div>The Lily Of Night</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/megamagmaoid.gif" border="0">      <div>The Mega Magmaoid</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/themonster.gif" border="0">      <div>The Monster</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/moonlightaster.gif" border="0">      <div>The Moonlight Aster</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/nightmarebeast.gif" border="0">      <div>The Nightmare Beast</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/paleworm.gif" border="0">      <div>The Pale Worm</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/rootkraken.gif" border="0">      <div>The Rootkraken</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/sandkingfinal.gif" border="0">      <div>The Sandking</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/scourgeofoblivion00.gif" border="0">      <div>The Scourge Of Oblivion</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/souldespoiler.gif" border="0">      <div>The Souldespoiler</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/sourceofcorruption.gif" border="0">      <div>The Source Of Corruption</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/timeguardian.gif" border="0">      <div>The Time Guardian</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/voidbornvulnerable.gif" border="0">      <div>The Unarmored Voidborn</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/theunwelcome.gif" border="0">      <div>The Unwelcome</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/winterbloom.gif" border="0">      <div>The Winter Bloom</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/timira.gif" border="0">      <div>Timira The Many-Headed</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/unaz.gif" border="0">      <div>Unaz The Mean</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/urmahlulluweakest.gif" border="0">      <div>Urmahlullu The Weakened</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/utua.gif" border="0">      <div>Utua Stone Sting</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/vemiath.gif" border="0">      <div>Vemiath</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/vok.gif" border="0">      <div>Vok The Freakish</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/yirkass.gif" border="0">      <div>Yirkas Blue Scales</div>    </div>    <div style="width: 100px; height: 110px; margin: 0px; float: left;">      <img src="https://static.tibia.com/images/library/zamulosh.gif" border="0">      <div>Zamulosh</div>    </div>  </div></div>        </div>
+      </div>
+    </div>
+    <div class="Border_1" style="background-image:url(https://static.tibia.com/images/global/content/border-1.gif);"></div>
+    <div class="CornerWrapper-b"><div class="Corner-bl" style="background-image:url(https://static.tibia.com/images/global/content/corner-bl.gif);"></div></div>
+    <div class="CornerWrapper-b"><div class="Corner-br" style="background-image:url(https://static.tibia.com/images/global/content/corner-br.gif);"></div></div>
+  </div>
+      <div id="Footer" class="main-footer">
+        Copyright by CipSoft GmbH. All rights reserved.<br>
+        <a href="https://www.tibia.com/abouttibia/?subtopic=aboutcipsoft">About CipSoft</a> | <a href="https://www.tibia.com/support/?subtopic=legaldocuments&amp;page=agreement">Service Agreement</a> | <a href="https://www.tibia.com/support/?subtopic=legaldocuments&amp;page=privacy">Privacy Policy</a>
+      </div>
+    </div>
+    <div class="main-themboxes Themeboxes">
+      <div id="DeactivationContainerThemebox" onclick="StopVideoIfExists();DisableDeactivationContainer();"></div>
+      <div id="PremiumBox" class="Themebox" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/themebox.png);"><div id="PremiumBoxDecor" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/coin_animation.gif);"></div><div id="PremiumBoxBg" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/coins_trade.png);"></div><div id="PremiumBoxOverlay" style="background-image:url(https://static.tibia.com/images//global/themeboxes/premium/type_overlay.png);"><p id="PremiumBoxOverlayText">Trade Tibia Coins!</p></div><div id="PremiumBoxButton"><form action="https://www.tibia.com/account/index.php?subtopic=redirectlogin&amp;redirect=https%3A%2F%2Fwww.tibia.com%2Faccount%2F%3Fsubtopic%3Daccountmanagement%23Products%2BAvailable" method="post" style="padding:0px;margin:0px;"><div class="WebshopButton" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/button.png)"><div onmouseover="MouseOverWebshopButton(this);" onmouseout="MouseOutWebshopButton(this);"><div class="WebshopButtonOver" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/button_hover.png);"></div><input class="WebshopButtonText" type="image" name="Get Coins" alt="Get Coins" src="https://static.tibia.com/images/global/themeboxes/premium/get_tibia_coins.png"></div></div></form></div><div id="PremiumBoxButtonDecor" style="background-image:url(https://static.tibia.com/images/global/themeboxes/premium/button_tibia_coins.png);"></div></div>  <!-- random fansite theme box -->
+  <div id="FansiteBox" class="Themebox" style="background-image:url(https://static.tibia.com/images/global/themeboxes/fansites/fansites_themebox.gif);">
+    <div id="FansiteLogoFrame" style="background-image:url(https://static.tibia.com/images/global/themeboxes/fansites/border_promoted.gif);">
+      <a href="https://www.tibiafanart.com/" target="_blank" rel="noopener noreferrer"><img id="FansiteLogo" src="https://static.tibia.com/images/community/fansitelogos/TibiaFanart.gif"></a>
+    </div>
+    <div class="ThemeboxButton">
+      <div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue.gif)"><div onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue_over.gif);"></div><a class="BigButtonText" href="https://www.tibia.com/community/?subtopic=fansites">View all Fansites</a></div></div>    </div>
+    <div class="Bottom" style="background-image:url(https://static.tibia.com/images/global/general/box-bottom.gif);"></div>
+  </div>
+    </div>
+  </div>
+  <script type="text/javascript">
     // disable all control elements which are not part of the content container element
     if (g_Deactivated == true) {
       $(document).ready(function() {
@@ -816,5 +779,6 @@ Copyright by CipSoft GmbH. All rights reserved.<br />
       });
     }
   </script>
-<div id="HelperDivContainer" style="background-image: url(https://static.tibia.com/images/global/content/scroll.gif);"><div class="HelperDivArrow" style="background-image: url(https://static.tibia.com/images/global/content/helper-div-arrow.png);"></div><div id="HelperDivHeadline"></div><div id="HelperDivText"></div><center><img class="Ornament" src="https://static.tibia.com/images/global/content/ornament.gif" /></center><br /></div> </body>
-</html>
+  <div id="cookiedialogbackground"><div id="cookiedialogbox"><div class="TableContainer">  <div class="CaptionContainer">      <div class="CaptionInnerContainer">        <span class="CaptionEdgeLeftTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionEdgeRightTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionBorderTop" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span>        <span class="CaptionVerticalLeft" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);"></span>        <div class="Text"><div class="CookieHeaderText"> </div></div>        <span class="CaptionVerticalRight" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);"></span>        <span class="CaptionBorderBottom" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span>        <span class="CaptionEdgeLeftBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionEdgeRightBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>      </div>    </div><table class="Table5" cellpadding="0" cellspacing="0">        <tbody><tr>      <td>        <div class="TableScrollbarWrapper">          <div class="TableScrollbarContainer"> </div>        </div>        <div class="InnerTableContainer">          <div id="cookiedialogimage"><img src="https://static.tibia.com/images/global/general/warning-druid.png"></div><div id="cookiedialogcontent">Our website makes use of cookies (sadly not the delicious, crumbly ones) and similar technologies. If you accept them, we share information with our partners for social media, advertising and analysis.<br><br>Please let us know which cookies we can use.<div class="SubmitButtonRow"><div class="LeftButton"><div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue.gif)"><div class="ButtonEventHook" onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue_over.gif);"></div><input class="BigButtonText" type="button" onclick="HideCookieDialog();ShowCookieDetails();" value="Manage Cookies"></div></div></div><div class="RightButton"><div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_green.gif)"><div class="ButtonEventHook" onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_green_over.gif);"></div><input class="BigButtonText" type="button" onclick="SetConsentCookie(true, true);" value="Accept All"></div></div></div></div></div><table style="width:100%;">          </table>        </div>      </td>    </tr>  </tbody></table></div></div><div id="cookiedetailsbox"><div class="TableContainer">  <div class="CaptionContainer">      <div class="CaptionInnerContainer">        <span class="CaptionEdgeLeftTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionEdgeRightTop" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionBorderTop" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span>        <span class="CaptionVerticalLeft" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);"></span>        <div class="Text">Manage Cookies</div>        <span class="CaptionVerticalRight" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-vertical.gif);"></span>        <span class="CaptionBorderBottom" style="background-image:url(https://static.tibia.com/images/global/content/table-headline-border.gif);"></span>        <span class="CaptionEdgeLeftBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>        <span class="CaptionEdgeRightBottom" style="background-image:url(https://static.tibia.com/images/global/content/box-frame-edge.gif);"></span>      </div>    </div><table class="Table5" cellpadding="0" cellspacing="0">        <tbody><tr>      <td>        <div class="TableScrollbarWrapper">          <div class="TableScrollbarContainer"> </div>        </div>        <div class="InnerTableContainer">          <table style="width:100%;"><tbody><tr><td>  <div class="TableContentContainer ">    <table class="TableContent" width="100%" style="border:1px solid #faf0d7;"><tbody><tr><td><label class="switch"><input type="checkbox" id="cc_necessary" checked="true" disabled="disabled"><span class="slider round"></span></label></td><td class="cookiedetailscontent"><h3>Necessary</h3>These cookies are required in order for our website to function (e.g. logging in). If you set your browser to block or alert you about these cookies, some parts of the website might not work.<br><br></td></tr>    </tbody></table>  </div></td></tr><tr><td>  <div class="TableContentContainer ">    <table class="TableContent" width="100%" style="border:1px solid #faf0d7;"><tbody><tr><td><label class="switch"><input type="checkbox" id="cc_advertising"><span class="slider round"></span></label></td><td class="cookiedetailscontent"><h3>Targeting and Advertising</h3>Advertisers and other content providers that may appear on our website may also use cookies that are not sent by us. Such advertisements or content may use cookies to help track and target the interests of users of the website to present customised and personalised advertisements or other messages that the user might find interesting. We also use these cookies and so-called Tracking Pixels of our partners to measure and improve the effectiveness of marketing campaigns.<br><br></td></tr>    </tbody></table>  </div></td></tr><tr><td>  <div class="TableContentContainer ">    <table class="TableContent" width="100%" style="border:1px solid #faf0d7;"><tbody><tr><td><label class="switch"><input type="checkbox" id="cc_social"><span class="slider round"></span></label></td><td class="cookiedetailscontent"><h3>Social Media</h3>These cookies enable the website to provide enhanced functionality and personalisation. They may be set by third-party providers (like social networks or streaming platforms) whose services we use on the website. If you do not allow these cookies, some or all of these services may not function properly. (YouTube)<br><br></td></tr>    </tbody></table>  </div></td></tr><tr><td>  <div class="TableContentContainer ">    <table class="TableContent" width="100%" style="border:1px solid #faf0d7;"><tbody><tr><td><label class="switch"><input type="checkbox" id="cc_walletconnect"><span class="slider round"></span></label></td><td class="cookiedetailscontent"><h3>WalletConnect</h3>When using the Tibia Token Exchange feature on the Account Management page, the third party provider WalletConnect is used to connect to your cryptocurrency wallet. WalletConnect sets cookies to ensure the legitimacy of the application and to enable the connection to your wallet. If you do not allow these cookies, you cannot use the Tibia Token Exchange.<br><br></td></tr>    </tbody></table>  </div></td></tr><tr><td colspan="2"><div class="SubmitButtonRow"><div class="LeftButton"><div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue.gif)"><div class="ButtonEventHook" onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue_over.gif);"></div><input class="BigButtonText" type="button" onclick="HideCookieDetails();ShowCookieDialog();" value="Close"></div></div></div><div class="CenterButton"><div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue.gif)"><div class="ButtonEventHook" onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_blue_over.gif);"></div><input class="BigButtonText" type="button" onclick="SetConsentCookie(true, false);" value="Save Settings"></div></div></div><div class="RightButton"><div class="BigButton" style="background-image:url(https://static.tibia.com/images/global/buttons/button_green.gif)"><div class="ButtonEventHook" onmouseover="MouseOverBigButton(this);" onmouseout="MouseOutBigButton(this);"><div class="BigButtonOver" style="background-image:url(https://static.tibia.com/images/global/buttons/button_green_over.gif);"></div><input class="BigButtonText" type="button" onclick="SetConsentCookie(true, true);" value="Accept All"></div></div></div></div></td></tr>          </tbody></table>        </div>      </td>    </tr>  </tbody></table></div></div></div><div id="HelperDivContainer" style="background-image: url(https://static.tibia.com/images/global/content/scroll.gif);"><div class="HelperDivArrow" style="background-image: url(https://static.tibia.com/images/global/content/helper-div-arrow.png);"></div><div id="HelperDivHeadline"></div><div id="HelperDivText"></div><center><img class="Ornament" src="https://static.tibia.com/images/global/content/ornament.gif"></center><br></div><div id="BackToTopButton" class="MobileNavigationLinkContainer MobileNavigationMainElement"><a id="BackToTopArrowUp" href="#top"> </a></div>
+
+</body></html>


### PR DESCRIPTION
The bold text disappeared, causing parsing to fail.

Clients would experience:

```
2025-05-02 09:33:11 |  WARN |      x.n.s.s.ServerSaveScannerWorker | scanBoostedCreature() Failed to connect to Tibia.com: Boss title not found
```

The logic has been updated with current structure. The current boosted boss page was taken again for the tests.